### PR TITLE
Trigger GA only when pushing to the main branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,8 @@
 name: CI
-on: push
+on: 
+  push:
+    branches:
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This disables creating the web page on a push to any branch